### PR TITLE
docs: Add README for OctoAcme Project Management Docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,36 @@
+# OctoAcme Project Management Docs
+
+Welcome to the OctoAcme program process documentation! This repository centralizes key project management best practices, templates, and guidelines, making them searchable and accessible to all team members for consistent, efficient project delivery.
+
+## Overview of OctoAcme Project Management Processes
+
+OctoAcme employs a structured, lifecycle-based project management approach designed to balance iterative delivery with clear stakeholder alignment. The organization uses five key phases—**Initiation, Planning, Execution & Tracking, Release & Deployment, and Retrospective & Continuous Improvement**—to guide projects from conception through completion.
+
+Each phase is supported by lightweight but rigorous artifacts: the Project One-pager establishes the business case and success metrics during initiation; the prioritized backlog with acceptance criteria and Definition of Done guide execution; and risk registers, communication plans, and status dashboards keep stakeholders informed and aligned. This architecture emphasizes customer-first principles, psychological safety, and data-informed decision-making to ensure teams deliver measurable value in small, testable increments.
+
+Central to OctoAcme's success are clearly defined roles with complementary responsibilities. **Project Managers** coordinate delivery activities, manage schedules, risks, and communications. **Product Managers** own the vision, prioritize the backlog, and measure outcomes through customer research and metrics. **Developers** implement features while contributing to design, testing, and risk identification. **QA/Testing teams** validate quality and acceptance criteria. This clear ownership structure prevents gaps and ensures accountability, while cross-functional collaboration keeps all perspectives represented.
+
+Communication and risk management are woven throughout OctoAcme's processes. Weekly syncs between PM and Product Lead, twice-weekly team standups, and monthly stakeholder updates create a predictable rhythm for alignment. The organization maintains an active Risk Register tracking impact, likelihood, ownership, and mitigation for each identified issue, with escalation paths that move from team-level triage through PM and Product Lead to sponsor-level intervention for business-critical blockers.
+
+Quality assurance is embedded into every stage of the delivery cycle. Unit and integration tests are required for new logic; end-to-end smoke tests validate critical flows before release; and security scanning runs in CI pipelines. Before any production deployment, the team verifies that all acceptance criteria are met, tests pass, release notes are drafted, and a rollback plan is documented. This layered approach to quality—combining automated checks, manual validation where needed, and pre-deployment verification—minimizes risk and ensures reliable releases.
+
+## 📚 Core Process Documentation
+
+- [Project Management Overview](./octoacme-project-management-overview.md) — Core principles, roles, artifacts, and lifecycle
+- [Project Initiation Guide](./octoacme-project-initiation.md) — Validating ideas, stakeholder alignment, and decision gates
+- [Project Planning](./octoacme-project-planning.md) — Breaking work into shippable increments and creating backlogs
+- [Execution & Tracking](./octoacme-execution-and-tracking.md) — Daily execution, testing, and progress tracking
+- [Risk Management & Communication](./octoacme-risks-and-communication.md) — Identifying risks and keeping stakeholders informed
+- [Release & Deployment Guide](./octoacme-release-and-deployment.md) — Pre-release checklists and safe deployment practices
+- [Retrospective & Continuous Improvement](./octoacme-retrospective-and-continuous-improvement.md) — Capturing learnings and driving improvements
+- [Roles & Personas](./octoacme-roles-and-personas.md) — Definitions of key project roles and responsibilities
+
+---
+
+## Getting Started
+
+- **New to OctoAcme?** Start with the [Project Management Overview](./octoacme-project-management-overview.md)
+- **Starting a project?** Follow the [Project Initiation Guide](./octoacme-project-initiation.md)
+- **Have feedback?** Open an issue using the [Process Doc Update template](../.github/ISSUE_TEMPLATE/add-update-content-to-process-docs.yml)
+
+For improvements or suggestions, please open an issue or pull request!


### PR DESCRIPTION
## Summary
Adds a comprehensive README to the `docs/` folder that centralizes the OctoAcme project management process overview and provides organized navigation to all core documentation files.

## Changes
- New `docs/README.md` with process overview and document links
- Summarizes key principles, lifecycle phases, roles, and practices
- Improves discoverability and accelerates onboarding

Closes #2