### PR TITLE
docs: Expand roles & personas and add incident response guidance

### DIFF
--- a/docs/octoacme-incident-response.md
+++ b/docs/octoacme-incident-response.md
@@ -1,0 +1,130 @@
+# OctoAcme — Incident Response & Post-Mortems
+
+## Purpose
+Provide guidance for rapid incident triage, response, and post-incident learning.
+
+## Incident Classification
+
+### Severity Levels
+
+**Critical (Sev 1)**
+- Production outage or data loss
+- All customers affected or revenue impacted
+- Immediate response required
+- Escalate to Sponsor
+
+**High (Sev 2)**
+- Significant functionality unavailable
+- Multiple customers affected
+- Degraded experience or workaround available
+- Response within 30 min
+
+**Medium (Sev 3)**
+- Limited functionality impact
+- Single customer or feature affected
+- Workaround available
+- Response within 2 hours
+
+**Low (Sev 4)**
+- Minor issue or cosmetic bug
+- No customer impact or minimal workaround
+- Can be addressed in normal sprint
+
+## Incident Response Workflow
+
+### 1. Detection & Triage (First 5-15 min)
+- Alert triggers monitoring system
+- On-call engineer or Support Lead notified
+- Severity assigned using classification above
+- Incident channel opened (Slack, PagerDuty, etc.)
+
+### 2. Response Team Assembly
+- On-call engineer (Incident Commander)
+- Support/Operations Lead
+- Relevant Tech Lead or Engineer
+- Security Lead (if security-related)
+- Product Manager (kept informed)
+
+### 3. Rapid Triage (First 15-30 min)
+- Confirm incident scope and customer impact
+- Check recent deployments, config changes, or anomalies
+- Attempt quick remediation or rollback if safe
+- Communicate status to stakeholders
+
+### 4. Investigation & Remediation (30 min – ongoing)
+- Root cause investigation
+- Document timeline and actions taken
+- Implement fix or workaround
+- Prepare rollback plan if needed
+- Communicate progress to stakeholders
+
+### 5. Deployment & Verification (Ongoing)
+- Deploy fix to staging, verify
+- Deploy to production when ready
+- Post-deployment verification and monitoring
+- Confirm customer impact resolved
+
+### 6. Communication
+- Initial notification: "Incident declared at [time], investigating"
+- 30-min updates: progress and ETA
+- Resolution: "Issue resolved at [time], investigating root cause"
+- Post-incident: summary and action items
+
+## Incident Communication Template
+
+## Blameless Post-Incident Retrospective
+
+### Timing
+- Schedule within 24-48 hours of resolution
+- Include: Incident Commander, on-call engineer, Tech Lead, Support Lead, Product Manager
+
+### Agenda (60 min)
+1. Timeline review (15 min)
+   - When did monitoring alert?
+   - When was incident declared?
+   - What actions were taken and when?
+
+2. Root cause analysis (20 min)
+   - What triggered the incident?
+   - Why did detection/response take [X] time?
+   - What made it difficult to resolve?
+
+3. Action items (15 min)
+   - What can we do to prevent recurrence?
+   - What can we do to detect faster?
+   - What can we do to resolve faster?
+   - Assign owner and due date to each
+
+4. Celebrate learnings (10 min)
+   - What did we do well?
+   - Thank participants for rapid response
+
+### Action Item Template
+- **Title:** [Brief description]
+- **Root Cause:** [What incident revealed]
+- **Owner:** [Name]
+- **Due Date:** [Target]
+- **Success Criteria:** [How we'll know it's done]
+- **Priority:** [High/Medium/Low]
+
+## Post-Incident Follow-up
+- Add action items to project backlog with "incident" label
+- Follow up on action items in weekly PM sync
+- Track and celebrate completed improvements
+- Share summary and learnings with team (anonymized if needed)
+
+## Escalation Paths
+
+**For Production Incidents:**
+- Level 1: On-call engineer + Support Lead + Tech Lead
+- Level 2: Incident Commander + Product Lead
+- Level 3: Sponsor (for Sev 1 critical issues)
+
+**For Security Incidents:**
+- Follow Security Incident Runbook
+- Notify Security Lead and on-call immediately
+- Escalate to Security Officer and Legal if breach or compliance issue
+
+## References
+- [Risk Management & Communication](./octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](./octoacme-release-and-deployment.md)

--- a/docs/octoacme-roles-and-personas.md
+++ b/docs/octoacme-roles-and-personas.md
@@ -1,4 +1,4 @@
-# OctoAcme Personas
+# OctoAcme Personas & Roles
 
 This document defines typical roles and responsibilities used in OctoAcme project docs and exercises.
 
@@ -15,6 +15,7 @@ Developers design, build, test, and deliver software components. They collaborat
 - Participate in design and code reviews
 - Assist in estimating and planning work
 - Help identify technical risks and propose mitigations
+- Participate in daily standups and sprint planning
 
 ### Goals
 - Deliver reliable, maintainable code
@@ -38,6 +39,8 @@ Product Managers define what should be built to deliver customer and business va
 - Prioritize the roadmap and backlog
 - Collaborate with stakeholders and engineering on trade-offs
 - Validate solutions through user research and metrics
+- Partner with Project Manager on planning and execution
+- Review and sign off on release readiness
 
 ### Goals
 - Maximize customer value and impact
@@ -48,6 +51,7 @@ Product Managers define what should be built to deliver customer and business va
 - Weekly alignment with PM and engineering leads
 - Roadmap updates and stakeholder briefings
 - Acceptance criteria and feature specs
+- Monthly stakeholder updates
 
 ---
 
@@ -62,6 +66,8 @@ Project Managers coordinate delivery activities, manage schedules, risks, and co
 - Facilitate meetings (kickoff, planning, retrospectives)
 - Ensure consistent project documentation and status reporting
 - Coordinate cross-team and stakeholder communication
+- Escalate blockers and dependencies
+- Track progress against milestones and metrics
 
 ### Goals
 - Deliver projects on time and within scope
@@ -75,7 +81,170 @@ Project Managers coordinate delivery activities, manage schedules, risks, and co
 
 ---
 
-## How these personas are used in the exercise
-- Use these persona definitions to frame scenarios and sample interactions in the Skills Exercise.
-- Each persona can be used as a persona prompt for Copilot Spaces to shape role-specific guidance.
+## QA / Testing Specialists
 
+### Role Summary
+QA/Testing specialists validate software quality and ensure all deliverables meet acceptance criteria before release. They collaborate with developers, product managers, and operations teams.
+
+### Responsibilities
+- Develop and maintain test plans aligned with acceptance criteria
+- Execute manual and automated testing across all environments
+- Manage test data and environments
+- Identify, document, and verify resolution of defects
+- Participate in definition of acceptance criteria during planning
+- Validate pre-release requirements and smoke tests
+- Provide feedback on testability and quality standards
+- Support post-deployment verification
+
+### Goals
+- Ensure all releases meet quality and acceptance standards
+- Reduce production defects and regressions
+- Build confidence in deployment safety
+
+### Typical Communication
+- Participation in planning and definition of done workshops
+- Test result summaries and defect reports
+- Daily standup updates on QA blockers
+- Sign-off on release readiness
+
+---
+
+## Tech Leads / Engineering Leads
+
+### Role Summary
+Tech Leads provide technical direction and leadership on complex initiatives. They collaborate with product and project management while maintaining code quality and architectural integrity.
+
+### Responsibilities
+- Provide technical guidance on design, architecture, and trade-offs
+- Identify and advocate for addressing technical debt
+- Mentor developers and review code quality
+- Assess technical feasibility and risks
+- Collaborate on estimation and capacity planning
+- Lead design reviews and technical discussions
+- Support incident response and root-cause analysis
+
+### Goals
+- Maintain technical excellence and system health
+- Reduce technical risk and complexity
+- Ensure scalable, maintainable solutions
+
+### Typical Communication
+- Technical design discussions and architecture reviews
+- Code review and mentoring
+- Risk register input on technical issues
+- Participation in sprint planning and retrospectives
+
+---
+
+## Stakeholders & Sponsors
+
+### Role Summary
+Stakeholders and Sponsors provide business context, approval, and oversight. They ensure projects align with organizational priorities and receive timely updates on progress and risks.
+
+### Responsibilities
+- Define business goals and success criteria in collaboration with Product Manager
+- Provide business and domain expertise during planning
+- Approve go/no-go decisions at initiation and milestone gates
+- Review and approve project charter and resource allocation
+- Receive regular status updates and escalations
+- Make trade-off decisions on scope, timeline, and resources
+- Participate in retrospectives and lessons learned
+
+### Goals
+- Ensure projects deliver business value and ROI
+- Maintain visibility and control over project direction
+- Support team success through timely decision-making
+
+### Typical Communication
+- Kickoff and checkpoint meetings
+- Monthly stakeholder updates
+- Escalation of business-critical blockers
+- Retrospective participation
+
+---
+
+## Security Lead / Security Officer
+
+### Role Summary
+Security Leads ensure that projects incorporate security best practices and maintain compliance. They are involved in planning, review, incident response, and release verification.
+
+### Responsibilities
+- Conduct or review security assessments for new features
+- Define security requirements and acceptance criteria
+- Monitor and oversee security scanning in CI/CD pipelines
+- Review pre-release security checklist
+- Lead security incident response and triage
+- Provide security training and guidance to team
+- Maintain security documentation and runbooks
+
+### Goals
+- Prevent security vulnerabilities and breaches
+- Ensure compliance with security standards and policies
+- Enable rapid incident response and recovery
+
+### Typical Communication
+- Security requirement input during planning
+- Security scanning results and remediation tracking
+- Incident response coordination
+- Post-incident blameless retrospectives
+
+---
+
+## Support / Operations Lead
+
+### Role Summary
+Support and Operations Leads manage production systems, customer communication, and incident response. They are critical partners during planning and release activities.
+
+### Responsibilities
+- Define operational requirements (logging, monitoring, runbooks)
+- Participate in release planning and pre-deployment coordination
+- Execute deployment activities (or coordinate with DevOps/SRE)
+- Manage post-deployment verification and monitoring
+- Lead incident triage and response coordination
+- Provide customer-facing incident communication
+- Capture operational metrics and post-incident action items
+
+### Goals
+- Maintain system reliability and uptime
+- Rapidly triage and resolve production incidents
+- Minimize customer impact during incidents
+
+### Typical Communication
+- Operational requirements input during planning
+- Deployment coordination and release notes
+- Incident response and escalation
+- Post-incident retrospectives
+
+---
+
+## Cross-Functional Collaboration Matrix
+
+| Activity | PM | PdM | Developers | QA | Tech Lead | Stakeholder | Security | Support |
+|----------|----|----|-----------|-----|-----------|-------------|----------|---------|
+| Project Initiation | Lead | Collaborate | — | — | — | Approve | Consult | Consult |
+| Planning & Kickoff | Lead | Lead | Participate | Participate | Participate | Approve | Consult | Consult |
+| Design Review | Facilitate | Input | Lead | Input | Participate | — | Consult | — |
+| Execution | Track | Monitor | Execute | Execute | Guide | — | Monitor | — |
+| Testing & QA | Track | Input | Collaborate | Lead | Consult | — | Consult | — |
+| Security Review | Coordinate | Input | Consult | Consult | Participate | — | Lead | — |
+| Release Planning | Lead | Lead | Input | Input | Input | Approve | Lead | Lead |
+| Deployment | Coordinate | Sign-off | Support | Verify | Support | Notify | Monitor | Execute |
+| Incident Response | Coordinate | Notify | Support | Verify | Lead | Escalate | Lead | Lead |
+| Retrospective | Facilitate | Participate | Participate | Participate | Participate | Participate | Participate | Participate |
+
+---
+
+## How These Personas Are Used
+
+- Use these persona definitions to frame scenarios and sample interactions in exercises
+- Each persona can be used as a persona prompt for Copilot Spaces to shape role-specific guidance
+- Reference this document when defining responsibilities in project charters and team structures
+- Use the collaboration matrix to clarify handoffs and decision points
+
+---
+
+## Related Documentation
+- [Project Management Overview](./octoacme-project-management-overview.md)
+- [Project Initiation Guide](./octoacme-project-initiation.md)
+- [Risk Management & Communication](./octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](./octoacme-release-and-deployment.md)


### PR DESCRIPTION
## Summary
Addresses issue #4 by expanding the OctoAcme roles and personas documentation and adding critical incident response procedures.

## Changes
- Updated `octoacme-roles-and-personas.md`:
  - Added QA/Testing Specialist persona
  - Added Tech Lead/Engineering Lead persona
  - Added Stakeholder/Sponsor persona
  - Added Security Lead persona
  - Added Support/Operations Lead persona
  - Added cross-functional collaboration matrix

- Created `octoacme-incident-response.md`:
  - Incident classification and severity levels
  - Multi-stage incident response workflow
  - Blameless post-incident retrospective guide
  - Communication templates and escalation paths
  - Addresses gap referenced in Release & Deployment and Risk Management docs

## Rationale
The existing docs reference QA, Security, Support, and stakeholder roles but didn't formally document their responsibilities. Additionally, incident response was mentioned but not fully documented. These updates provide clarity on roles, decision-making authority, and incident management procedures.

## Closes #4